### PR TITLE
Change docsrs feature to reflect changes in the compiler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ this crate can be used without the standard library.
 #![no_std]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 extern crate alloc;
 #[cfg(any(test, feature = "std"))]


### PR DESCRIPTION
The `doc_auto_cfg` feature was removed and its functionality merged into `doc_cfg`. This PR fixes this.

```
error[E0557]: feature has been removed
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/aho-corasick-1.1.3/src/lib.rs:230:29
    |
230 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
    |                             ^^^^^^^^^^^^ feature has been removed
    |
    = note: removed in CURRENT_RUSTC_VERSION; see <https://github.com/rust-lang/rust/pull/138907> for more information
    = note: merged into `doc_cfg`

error: Compilation failed, aborting rustdoc
```